### PR TITLE
fix(kubefwd): add version prefix to release URL

### DIFF
--- a/vars/kubefwd.yml
+++ b/vars/kubefwd.yml
@@ -4,7 +4,7 @@ gh_role_installer_version: "latest"
 gh_role_installer_os: "Linux"
 gh_role_installer_arch: "x86_64"
 gh_role_installer_repository: "txn2/kubefwd"
-gh_role_installer_release: "https://github.com/{{ gh_role_installer_repository }}/releases/download/{{ version_to_install }}/kubefwd_{{ gh_role_installer_os }}_{{ gh_role_installer_arch }}.tar.gz"
+gh_role_installer_release: "https://github.com/{{ gh_role_installer_repository }}/releases/download/v{{ version_to_install }}/kubefwd_{{ gh_role_installer_os }}_{{ gh_role_installer_arch }}.tar.gz"
 gh_role_installer_release_is_archive: true
 gh_role_installer_binary_name: "kubefwd"
 gh_role_installer_cmd_to_get_version: kubefwd version | grep version | awk '{ print $3 }'


### PR DESCRIPTION
Add "v" prefix to version in download URL to match actual GitHub release tag format (v1.25.8 instead of 1.25.8)