### PR TITLE
feat(llmfit): add llmfit tool support

### DIFF
--- a/.github/workflows/llmfit.yml
+++ b/.github/workflows/llmfit.yml
@@ -1,0 +1,31 @@
+---
+name: CI-llmfit
+'on':
+  schedule:
+    - cron: "20 21 15 * *"
+
+jobs:
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - ubuntu2404
+          # - debian12
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.14.0
+
+      - name: Run Molecule tests.
+        run: |
+          devbox run -- molecule test -s llmfit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/Taskfile-tests.yml
+++ b/Taskfile-tests.yml
@@ -77,6 +77,7 @@ tasks:
       - task: test-kubevpn
       - task: test-kubie
       - task: test-lazygit
+      - task: test-llmfit
       - task: test-lnav
       - task: test-lsd
       - task: test-mdtohtml
@@ -465,6 +466,11 @@ tasks:
     cmds:
       - echo "Running tests for lazygit"
       - devbox run -- molecule test -s lazygit
+  test-llmfit:
+    desc: "Run tests for llmfit"
+    cmds:
+      - echo "Running tests for llmfit"
+      - devbox run -- molecule test -s llmfit
   test-lnav:
     desc: "Run tests for lnav"
     cmds:

--- a/docs/available_tools.md
+++ b/docs/available_tools.md
@@ -938,6 +938,20 @@ Here is a list of available tools that can be installed with self contained vari
         name: sgaunet.gh_role_installer
         vars_from: lazygit.yml
 ```
+## llmfit
+
+[Github repository](https://github.com/AlexsJones/llmfit)
+
+```
+- name: Install llmfit
+  hosts: all
+  become: true
+  tasks:
+    - name: "Install llmfit"
+      ansible.builtin.include_role:
+        name: sgaunet.gh_role_installer
+        vars_from: llmfit.yml
+```
 ## lnav
 
 [Github repository](https://github.com/tstack/lnav)

--- a/docs/badges.md
+++ b/docs/badges.md
@@ -70,6 +70,7 @@ Be patient, it will be fixed.
 [![CI](https://github.com/sgaunet/ansible-role-gh-release-installer/workflows/CI-kubevpn/badge.svg)](https://github.com/sgaunet/ansible-role-gh-release-installer/actions?query=workflow%3ACI-kubevpn)
 [![CI](https://github.com/sgaunet/ansible-role-gh-release-installer/workflows/CI-kubie/badge.svg)](https://github.com/sgaunet/ansible-role-gh-release-installer/actions?query=workflow%3ACI-kubie)
 [![CI](https://github.com/sgaunet/ansible-role-gh-release-installer/workflows/CI-lazygit/badge.svg)](https://github.com/sgaunet/ansible-role-gh-release-installer/actions?query=workflow%3ACI-lazygit)
+[![CI](https://github.com/sgaunet/ansible-role-gh-release-installer/workflows/CI-llmfit/badge.svg)](https://github.com/sgaunet/ansible-role-gh-release-installer/actions?query=workflow%3ACI-llmfit)
 [![CI](https://github.com/sgaunet/ansible-role-gh-release-installer/workflows/CI-lnav/badge.svg)](https://github.com/sgaunet/ansible-role-gh-release-installer/actions?query=workflow%3ACI-lnav)
 [![CI](https://github.com/sgaunet/ansible-role-gh-release-installer/workflows/CI-lsd/badge.svg)](https://github.com/sgaunet/ansible-role-gh-release-installer/actions?query=workflow%3ACI-lsd)
 [![CI](https://github.com/sgaunet/ansible-role-gh-release-installer/workflows/CI-mdtohtml/badge.svg)](https://github.com/sgaunet/ansible-role-gh-release-installer/actions?query=workflow%3ACI-mdtohtml)

--- a/molecule/llmfit/converge.yml
+++ b/molecule/llmfit/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+    - name: "Install llmfit"
+      ansible.builtin.include_role:
+        name: "sgaunet.gh_role_installer"
+        vars_from: "llmfit.yml"

--- a/molecule/llmfit/molecule.yml
+++ b/molecule/llmfit/molecule.yml
@@ -1,0 +1,19 @@
+---
+role_name_check: 1
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible

--- a/molecule/llmfit/verify.yml
+++ b/molecule/llmfit/verify.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include default vars
+      ansible.builtin.include_vars:
+        file: '{{ lookup("env", "MOLECULE_PROJECT_DIRECTORY") }}/vars/llmfit.yml'
+
+    - name: Stat gh_role_installer {{ gh_role_installer_binary_name }}
+      ansible.builtin.stat:
+        path: "{{ gh_role_installer_binary_path }}"
+      register: gh_role_installer_present
+    - name: Check binary is present {{ gh_role_installer_binary_name }}
+      ansible.builtin.assert:
+        that:
+          - gh_role_installer_present.stat.exists
+        fail_msg: "gh_role_installer not setup"
+        success_msg: "gh_role_installer is setup"

--- a/vars/llmfit.yml
+++ b/vars/llmfit.yml
@@ -1,0 +1,12 @@
+---
+
+gh_role_installer_version: "latest"
+gh_role_installer_os: "unknown-linux-musl"
+gh_role_installer_arch: "x86_64"
+gh_role_installer_repository: "AlexsJones/llmfit"
+gh_role_installer_release: "https://github.com/{{ gh_role_installer_repository }}/releases/download/v{{ version_to_install }}/llmfit-v{{ version_to_install }}-{{ gh_role_installer_arch }}-{{ gh_role_installer_os }}.tar.gz"
+gh_role_installer_release_is_archive: true
+gh_role_installer_binary_name: "llmfit"
+gh_role_installer_cmd_to_get_version: "llmfit --version | awk '{ print $2 }'"
+gh_role_installer_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}"
+gh_role_installer_binary_path: "/usr/local/bin/{{ gh_role_installer_binary_name }}"


### PR DESCRIPTION
## Summary
- Add [llmfit](https://github.com/AlexsJones/llmfit) tool support (Rust CLI to right-size LLM models to system hardware)
- Uses `unknown-linux-musl` x86_64 release archive
- Auto-generated molecule tests, CI workflow, docs, and Taskfile entries

Closes #149