### PR TITLE
fix(mise): install to SSH user's home under become

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@
 # gh_role_installer_cmd_to_get_version: "jwt-cli version"
 gh_role_installer_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}"
 gh_role_installer_binary_path: "/usr/local/bin/{{ gh_role_installer_binary_name }}"
+
+gh_role_installer_become: true

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -60,6 +60,7 @@
         path: "{{ gh_role_installer_binary_path | dirname }}"
         state: directory
         mode: '0755'
+      become: "{{ gh_role_installer_become }}"
 
     - name: Download the release ({{ gh_role_installer_repository }})
       ansible.builtin.get_url:
@@ -98,10 +99,11 @@
       ansible.builtin.copy:
         src: "{{ gh_role_installer_binary.files[0].path }}"
         dest: "{{ gh_role_installer_binary_path }}"
-        owner: root
-        group: root
+        owner: "{{ gh_role_installer_owner | default(omit) }}"
+        group: "{{ gh_role_installer_group | default(omit) }}"
         mode: "0755"
         remote_src: true
+      become: "{{ gh_role_installer_become }}"
       when:
         - gh_role_installer_release_is_archive
 
@@ -109,10 +111,11 @@
       ansible.builtin.copy:
         src: "{{ gh_role_installer_tmp_directory }}/{{ gh_role_installer_binary_name }}/{{ filename }}"
         dest: "{{ gh_role_installer_binary_path }}"
-        owner: root
-        group: root
+        owner: "{{ gh_role_installer_owner | default(omit) }}"
+        group: "{{ gh_role_installer_group | default(omit) }}"
         mode: "0755"
         remote_src: true
+      become: "{{ gh_role_installer_become }}"
       when:
         - not gh_role_installer_release_is_archive
 

--- a/vars/mise.yml
+++ b/vars/mise.yml
@@ -7,6 +7,8 @@ gh_role_installer_repository: "jdx/mise"
 gh_role_installer_release: "https://github.com/{{ gh_role_installer_repository }}/releases/download/v{{ version_to_install }}/mise-v{{ version_to_install }}-{{ gh_role_installer_os }}-{{ gh_role_installer_arch }}"
 gh_role_installer_release_is_archive: false
 gh_role_installer_binary_name: "mise"
-gh_role_installer_cmd_to_get_version: "{{ ansible_env.HOME }}/.local/bin/mise --version | awk '{ print $1 }'"
+gh_role_installer_cmd_to_get_version: "~/.local/bin/mise --version | awk '{ print $1 }'"
 gh_role_installer_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}"
-gh_role_installer_binary_path: "{{ ansible_env.HOME }}/.local/bin/{{ gh_role_installer_binary_name }}"
+gh_role_installer_binary_path: "~/.local/bin/{{ gh_role_installer_binary_name }}"
+
+gh_role_installer_become: false


### PR DESCRIPTION
- add gh_role_installer_become (default true) so per-tool installs can
  opt out of elevation, which is needed for user-home targets like
  ~/.local/bin
- drop hardcoded owner/group root:root on the copy tasks; use
  default(omit) so the file inherits the executing user's ownership
  unless a tool explicitly overrides
- mise: set gh_role_installer_become: false and keep ~/.local/bin paths;
  with become: false, ~ correctly resolves to the SSH user's home

Closes #154